### PR TITLE
#19 add CI regression gate and auto-merge Dependabot security patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# The regression gate. Runs the same `npm run verify` used locally —
+# typecheck, then vitest, then the Playwright pass — so one green check here
+# means the branch compiles and still behaves. Making this a required check on
+# main is what turns Dependabot auto-merge from "merge it" into "merge it if
+# the suite passes".
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push supersedes the run already in flight for the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      # Shallow is fine: build-albums' gitLastModified() falls back cleanly
+      # when history is missing, and only the generated sitemap dates depend
+      # on it. Cloudflare Workers Builds produces the deployed artifact.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # playwright.config.ts declares a single chromium project.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      # `preverify` regenerates src/data/albums.ts from public/memories first,
+      # so a photo added without rerunning build:albums fails here rather than
+      # silently shipping a stale album list.
+      - run: npm run verify

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+# Switches on GitHub's native auto-merge for the Dependabot PRs whose blast
+# radius is small. Auto-merge queues the PR and waits for the required checks,
+# so the actual decision belongs to them, not to this file. Both are required
+# on main by the `main-branch` ruleset:
+#
+#   verify               — typecheck + vitest + Playwright (ci.yml)
+#   Workers Builds: tipig — Cloudflare's build of the branch
+#
+# That pairing is load-bearing. With no required check, `gh pr merge --auto`
+# merges immediately and this workflow becomes an unconditional merger.
+on: pull_request
+
+# Workflow runs triggered by Dependabot get a read-only GITHUB_TOKEN by
+# default; this block grants the write scope `gh pr merge` needs.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Patch and minor only. A semver major on react, vite or wrangler can
+      # pass the whole suite and still change behaviour these tests don't
+      # reach, so majors stay open for a human to look at.
+      - name: Enable auto-merge
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #19.

Dependabot security PRs currently have nothing validating them. There is no GitHub Actions workflow running the test suite, and `claude-code-review` fails on bot-authored PRs before it starts (`Workflow initiated by non-human actor: dependabot`, plus an empty `CLAUDE_CODE_OAUTH_TOKEN` — Dependabot runs read from a separate secret store).

## `ci.yml`

Job `verify`, on PRs and pushes to `main`. Node 24, `npm ci` with cache, chromium only, then `npm run verify` — the same command used locally, so CI and local agree by construction.

Shallow checkout is safe: `gitLastModified()` in `scripts/build-albums.ts` already falls back when history is missing, and only generated sitemap dates depend on it.

## `dependabot-auto-merge.yml`

Job `auto-merge`, gated on the PR author being `dependabot[bot]`. Reads `dependabot/fetch-metadata@v2` and calls `gh pr merge --auto --squash` for `semver-patch` and `semver-minor` only — majors stay open for a human, since a major on react or vite can pass the suite and still change behaviour the tests don't reach.

Squash because the `main-branch` ruleset requires linear history. The explicit `permissions:` block lifts Dependabot's default read-only token to the write scope `gh pr merge` needs.

## Repo config applied alongside this branch

- `verify` and `Workers Builds: tipig` are now required status checks on `main`, each pinned to its app id.
- `strict_required_status_checks_policy: false` — deliberate; true would force every Dependabot branch up to date before merging, so each merge invalidates the rest and triggers a rebase loop.
- `allow_auto_merge` and `delete_branch_on_merge` enabled.

Auto-merge does nothing on its own here: it queues the PR and waits for those two checks. Without a required check, `--auto` would merge immediately.

## Verified locally

`typecheck` clean · `npm test` 67 passing across 6 files · `test:e2e` with `CI=true` 13 passing.

## Follow-up, not in this PR

`claude-code-review.yml` will keep failing on every Dependabot PR until it either gets `allowed_bots: 'dependabot'` plus a Dependabot-scoped token, or excludes bot PRs. It isn't a required check so it won't block auto-merge, but a permanently red check makes a real failure easy to miss.

After this merges, comment `@dependabot rebase` on #18 — it needs a fresh event to pick up either workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)