### PR TITLE
#21 let claude-review run on Dependabot pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,15 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          # Dependabot-triggered runs read from the Dependabot secret store,
+          # not the repository one, so this needs its own copy of the token:
+          #   gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot
+          # Without it the input resolves empty and the review can't authenticate.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The action refuses bot actors unless they're listed here. Both forms
+          # are given because the docs use the [bot] suffix while the rejection
+          # message reports the actor as bare "dependabot".
+          allowed_bots: 'dependabot[bot],dependabot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Closes #21. Follow-up to #19.

Adds `allowed_bots: 'dependabot[bot],dependabot'` to `claude-code-review.yml`.

Both forms are listed deliberately: the [action docs](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md) use the `[bot]` suffix (`"dependabot[bot],renovate[bot]"`), while the rejection message reports the actor as bare `dependabot`. Listing both costs nothing and avoids a second round trip if the comparison uses the short form.

## This alone will not make it pass

Dependabot-triggered runs read from the **Dependabot** secret store, not the repository one, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves empty — visible in the failing run as a blank value. It needs its own copy:

```
gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot --repo reykiit/tipig
```

That's noted in a comment directly above the input that consumes it, since the failure mode is otherwise invisible.

## Scope

`claude-review` is not a required status check, so this changes nothing about the merge gate — `verify` and `Workers Builds: tipig` remain the only things auto-merge waits on. This is about removing a permanent red X that would otherwise camouflage a real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)